### PR TITLE
Fix capitalization in many places

### DIFF
--- a/citations.bib
+++ b/citations.bib
@@ -13,7 +13,7 @@
 }
 
 @article{li2016potentially,
-  title={Potentially $\text{GL}_2$-type Galois representations associated to noncongruence modular forms},
+  title={Potentially {GL}$_2$-type {Galois} representations associated to noncongruence modular forms},
   author={Li, Wen-Ching Winnie and Liu, Tong and Long, Ling},
   journal={arXiv preprint arXiv:1609.06414},
   year={2016}
@@ -27,7 +27,7 @@
 }
 
 @article{jenkins2016dynamic,
-  title={Dynamic behavior of the roots of the Taylor polynomials of the Riemann xi function with growing degree},
+  title={Dynamic behavior of the roots of the Taylor polynomials of the {Riemann} xi function with growing degree},
   author={Jenkins, Robert and McLaughlin, Ken DT-R},
   journal={arXiv preprint arXiv:1609.05965},
   year={2016}
@@ -41,7 +41,7 @@
 }
 
 @article{long2016characterization,
-  title={Characterization of intersecting families of maximum size in $\text{PSL}(2,q)$},
+  title={Characterization of intersecting families of maximum size in {PSL}$(2,q)$},
   author={Long, Ling and Plaza, Rafael and Sin, Peter and Xiang, Qing},
   journal={arXiv preprint arXiv:1608.07304},
   year={2016}
@@ -90,7 +90,7 @@
   year={2016}
 }
 @article{harvey2016computing,
-  title={Computing L-series of geometrically hyperelliptic curves of genus three},
+  title={Computing {L}-series of geometrically hyperelliptic curves of genus three},
   author={Harvey, David and Massierer, Maike and Sutherland, Andrew V},
   journal={arXiv preprint arXiv:1605.04708},
   year={2016}
@@ -112,13 +112,13 @@
   publisher={JSTOR}
 }
 @article{mercuri2016equations,
-  title={Equations and Rational Points of the Modular Curves $ X\^{}+ \_0 (p) $},
+  title={Equations and Rational Points of the Modular Curves {X}$^+_0(p)$},
   author={Mercuri, Pietro},
   journal={arXiv preprint arXiv:1607.04558},
   year={2016}
 }
 @article{swinarski2016equations,
-  title={Equations of Riemann surfaces with automorphisms},
+  title={Equations of {Riemann} surfaces with automorphisms},
   author={Swinarski, David},
   journal={arXiv preprint arXiv:1607.04778},
   year={2016}
@@ -144,14 +144,14 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2016}
 }
 @article{sutherland2012computing,
-  title={Computing the image of Galois},
+  title={Computing the image of {Galois}},
   author={Sutherland, Andrew V},
   journal={CNTA XII},
   pages={22},
   year={2012}
 }
 @misc{roe2016algebraic,
-  title={Algebraic tori and a computational inverse Galois problem},
+  title={Algebraic tori and a computational inverse {Galois} problem},
   author={Roe, David},
   url={http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf},
   year={2016}
@@ -165,7 +165,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2013}
 }
 @misc{lmfdb2016functions,
-  title={The L-functions and Modular Forms Database (2016)},
+  title={The {L}-functions and Modular Forms Database (2016)},
   author={LMFDB Collaboration and others},
   url={http://lmfdb.org},
   year={2016}
@@ -198,7 +198,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2016}
 }
 @article{patrikis2015deformations,
-  title={Deformations of Galois representations and exceptional monodromy},
+  title={Deformations of {Galois} representations and exceptional monodromy},
   author={Patrikis, Stefan},
   journal={Inventiones mathematicae},
   pages={1--68},
@@ -206,7 +206,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Springer}
 }
 @article{johnson2015fourier,
-  title={Fourier coefficients for twists of Siegel paramodular forms (expanded version)},
+  title={Fourier coefficients for twists of {Siegel} paramodular forms (expanded version)},
   author={Johnson-Leung, Jennifer and Roberts, Brooks},
   journal={arXiv preprint arXiv:1505.05463},
   year={2015}
@@ -218,7 +218,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2015}
 }
 @article{klemm2015direct,
-  title={Direct Integration for Mirror Curves of Genus Two and an Almost Meromorphic Siegel Modular Form},
+  title={Direct Integration for Mirror Curves of Genus Two and an Almost Meromorphic {Siegel} Modular Form},
   author={Klemm, Albrecht and Poretschkin, Maximilian and Schimannek, Thorsten and Westerholt-Raum, Martin},
   journal={arXiv preprint arXiv:1502.00557},
   year={2015}
@@ -230,13 +230,13 @@ MRREVIEWER = {Rudra P. Sarkar},
   school={Universit{\"a}t zu K{\"o}ln}
 }
 @article{nelson2016quantum,
-  title={Quantum variance on quaternion algebras, I},
+  title={Quantum variance on quaternion algebras, {I}},
   author={Nelson, Paul D},
   journal={arXiv preprint arXiv:1601.02526},
   year={2016}
 }
 @article{grenie2015zeros,
-  title={Zeros of Dedekind zeta functions under GRH},
+  title={Zeros of {Dedekind} zeta functions under {GRH}},
   author={Greni{\'e}, Lo{\"\i}c and Molteni, Giuseppe},
   journal={Mathematics of Computation},
   volume={85},
@@ -244,13 +244,13 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2015}
 }
 @article{ryan2016computing,
-  title={Computing Jacobi Forms},
+  title={Computing {Jacobi} Forms},
   author={Ryan, Nathan C and Sirolli, Nicol{\'a}s and Skoruppa, Nils-Peter and Tornar{\'\i}a, Gonzalo},
   journal={arXiv preprint arXiv:1602.07021},
   year={2016}
 }
 @article{fite2015fields,
-  title={Fields of definition of elliptic $ k $-curves and the realizability of all genus 2 Sato--Tate groups over a number field},
+  title={Fields of definition of elliptic $k$-curves and the realizability of all genus 2 {Sato}-{Tate} groups over a number field},
   author={Fit{\'e}, Francesc and Guitart, Xavier},
   journal={arXiv preprint arXiv:1511.02322},
   year={2015}
@@ -268,7 +268,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2016}
 }
 @article{cooper2016beyond,
-  title={Beyond the excised ensemble: modelling elliptic curve L-functions with random matrices},
+  title={Beyond the excised ensemble: modelling elliptic curve {L}-functions with random matrices},
   author={Cooper, Ian A and Morris, Patrick W and Snaith, Nina C},
   journal={Journal of Physics A: Mathematical and Theoretical},
   volume={49},
@@ -320,7 +320,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2015}
 }
 @article{mosunov2015unconditional,
-  title={Unconditional class group tabulation of imaginary quadratic fields to $|\Delta|<2^{40}$},
+  title={Unconditional class group tabulation of imaginary quadratic fields to $|{\Delta}|<2^{40}$},
   author={Mosunov, A and Jacobson Jr,  M},
   journal={Mathematics of Computation},
   volume={85},
@@ -337,7 +337,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2014}
 }
 @article{rouse2013explicit,
-  title={The explicit Sato-Tate conjecture and densities pertaining to Lehmer-type questions},
+  title={The explicit {Sato}-{Tate} conjecture and densities pertaining to {Lehmer}-type questions},
   author={Rouse, Jeremy and Thorner, Jesse},
   journal={Transactions of the AMS},
   note={to appear},
@@ -351,7 +351,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2015}
 }
 @article{kraus2015theoreme,
-  title={Sur le th{\'e}or{\`e}me de Fermat sur $\mathbb Q(\sqrt5)$},
+  title={Sur le th{\'e}or{\`e}me de Fermat sur $\mathbb{Q}(\sqrt5)$},
   author={Kraus, Alain},
   journal={Annales math{\'e}matiques du Qu{\'e}bec},
   volume={39},
@@ -398,7 +398,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Cambridge University Press}
 }
 @mastersthesis{sohexplicit,
-  title={Explicit Methods for the Birch and Swinnerton-Dyer Conjecture},
+  title={Explicit Methods for the {Birch} and {Swinnerton}-{Dyer} Conjecture},
   type={MSc},
   institution={University of Oxford},
   author={Soh, Charlene}
@@ -432,14 +432,14 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Academic Press}
 }
 @article{brunault2015regulators,
-  title={Regulators for Rankin-Selberg products of modular forms},
+  title={Regulators for {Rankin}-{Selberg} products of modular forms},
   author={Brunault, Fran{\c{c}}ois and Chida, Masataka},
   journal={Annales math\'ematiques du Qu\'ebec},
   pages={1--29},
   year={2016}
 }
 @article{linowitz2015noncommutative,
-  title={A Noncommutative Analogue of the Odlyzko Bounds and Bounds on Performance for Space-Time Lattice Codes},
+  title={A Noncommutative Analogue of the {Odlyzko} Bounds and Bounds on Performance for Space-Time Lattice Codes},
   author={Linowitz, Benjamin and Satriano, Matthew and Vehkalahti, Roope},
   journal={Information Theory, IEEE Transactions on},
   volume={61},
@@ -449,18 +449,18 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={IEEE}
 }
 @article{kumar2014algebraic,
-  title={Algebraic models and arithmetic geometry of Teichm\"uller curves in genus two},
+  title={Algebraic models and arithmetic geometry of {Teichm\"uller} curves in genus two},
   author={Kumar, Abhinav and Mukamel, Ronen E},
   journal={arXiv preprint arXiv:1406.7057},
   year={2014}
 }
 @misc{cohencomputational,
-  title={Computational number theory in relation with L-functions},
+  title={Computational number theory in relation with {L}-functions},
   author={Cohen, Henri},
   url={http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf}
 }
 @article{sutherland2015computing,
-  title={Computing images of Galois representations attached to elliptic curves},
+  title={Computing images of {Galois} representations attached to elliptic curves},
   author={Sutherland, Andrew V},
   journal={Forum of Mathematics, Sigma},
   volume={4},
@@ -483,7 +483,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2015}
 }
 @article{ryan2014nonvanishing,
-  title={Nonvanishing of twists of-functions attached to Hilbert modular forms},
+  title={Nonvanishing of twists of-functions attached to {Hilbert} modular forms},
   author={Ryan, Nathan C and Tornaria, Gonzalo and Voight, John},
   journal={LMS Journal of Computation and Mathematics},
   volume={17},
@@ -493,7 +493,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Cambridge University Press}
 }
 @article{rahm2013level,
-  title={On level one cuspidal Bianchi modular forms},
+  title={On level one cuspidal {Bianchi} modular forms},
   author={Rahm, Alexander D and {\c{S}}eng{\"u}n, Mehmet Haluk},
   journal={LMS Journal of Computation and Mathematics},
   volume={16},
@@ -512,13 +512,13 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={World Scientific}
 }
 @mastersthesis{waltoncongruent,
-  title={The Congruent Number Problem and the Birch and Swinnerton-Dyer Conjecture},
+  title={The Congruent Number Problem and the {Birch} and {Swinnerton}-{Dyer} Conjecture},
   type={MMathPhil},
   institution={University of Oxford},
   author={Walton, Florence}
 }
 @article{ghitza2013computations,
-  title={Computations of vector-valued Siegel modular forms},
+  title={Computations of vector-valued {Siegel} modular forms},
   author={Ghitza, Alexandru and Ryan, Nathan C and Sulon, David},
   journal={Journal of Number Theory},
   volume={133},
@@ -528,7 +528,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Elsevier}
 }
 @mastersthesis{baker2015elliptic,
-  title={Elliptic Curves over Finite Fields and their l-Torsion Galois Representations},
+  title={Elliptic Curves over Finite Fields and their l-Torsion {Galois} Representations},
   type={M.S.},
   author={Baker, Michael},
   year={2015},
@@ -545,13 +545,13 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Mathematical Sciences Publishers}
 }
 @article{farmer2015varieties,
-  title={Varieties via their L-functions},
+  title={Varieties via their {L}-functions},
   author={Farmer, David W and Koutsoliotas, Sally and Lemurell, Stefan},
   journal={arXiv preprint arXiv:1502.00850},
   year={2015}
 }
 @mastersthesis{harris2015random,
-  title={Random Matrix Theory and the Attraction of Zeros of L-functions from the Central Point},
+  title={Random Matrix Theory and the Attraction of Zeros of {L}-functions from the Central Point},
   author={Harris, Katherine Elizabeth},
   type={Honors},
   institution={Bucknell University},
@@ -564,7 +564,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2013}
 }
 @article{mertens2014eichler,
-  title={Eichler-Selberg type identities for mixed mock modular forms},
+  title={{Eichler}-{Selberg} type identities for mixed mock modular forms},
   author={Mertens, Michael H},
   journal={arXiv preprint arXiv:1404.5491},
   year={2014}
@@ -576,7 +576,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2014}
 }
 @article{deines2016generalized,
-  title={Generalized Legendre curves and quaternionic multiplication},
+  title={Generalized {Legendre} curves and quaternionic multiplication},
   author={Deines, Alyson and Fuselier, Jenny G and Long, Ling and Swisher, Holly and Tu, Fang-Ting},
   journal={Journal of Number Theory},
   volume={161},
@@ -591,7 +591,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   school={University of Warwick}
 }
 @article{rubinstein2013elliptic,
-  title={Elliptic curves of high rank and the Riemann zeta function on the one line},
+  title={Elliptic curves of high rank and the {Riemann} zeta function on the one line},
   author={Rubinstein, Michael O},
   journal={Experimental Mathematics},
   volume={22},
@@ -645,7 +645,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   year={2015}
 }
 @article{katok2014fried,
-  title={The Fried average entropy and slow entropy for actions of higher rank abelian groups},
+  title={The {Fried} average entropy and slow entropy for actions of higher rank abelian groups},
   author={Katok, Anatole and Katok, Svetlana and Hertz, Federico Rodriguez},
   journal={Geometric and Functional Analysis},
   volume={24},
@@ -690,7 +690,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={World Scientific}
 }
 @article{farmer2014maass,
-  title={Maass Forms on GL(3) and GL(4)},
+  title={Maass Forms on {GL}(3) and {GL}(4)},
   author={Farmer, David W and Koutsoliotas, Sally and Lemurell, Stefan},
   journal={International mathematics research notices},
   volume={2014},
@@ -700,7 +700,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Oxford University Press}
 }
 @article{bachilov2014statistics,
-  title={On Statistics of the Riemann Zeros Differences},
+  title={On Statistics of the {Riemann} Zeros Differences},
   author={Bachilov, Yuri},
   journal={arXiv preprint arXiv:1402.0865},
   year={2014}
@@ -714,7 +714,7 @@ MRREVIEWER = {Rudra P. Sarkar},
   publisher={Springer}
 }
 @article{fite2012sato,
-  title={Sato-Tate groups of some weight 3 motives},
+  title={{Sato}-{Tate} groups of some weight 3 motives},
   author={Fit{\'e}, Francesc and Kedlaya, Kiran S and Sutherland, Andrew V},
   journal={Contemporary Mathematics},
   volume={663},

--- a/citations.bib
+++ b/citations.bib
@@ -111,10 +111,6 @@
   year={2016},
   publisher={JSTOR}
 }
-@article{michaelinteroperability,
-  title={Interoperability in the OpenDreamKit Project: The Math-in-the-Middle Approach},
-  author={Michael, Paul-Olivier Dehaye1 Mihnea Iancu and Konovalov, Kohlhase2 Alexander and Markus, Samuel Lelievre4 Dennis M{\"u}ller and Rabe, Pfeiffer3 Florian and Wiesing, Nicolas M Thi{\'e}ry4 Tom}
-}
 @article{mercuri2016equations,
   title={Equations and Rational Points of the Modular Curves $ X\^{}+ \_0 (p) $},
   author={Mercuri, Pietro},

--- a/citations.html
+++ b/citations.html
@@ -10,7 +10,7 @@
 
 <body>
 
-<!-- This document was automatically generated with bibtex2html 1.98
+<!-- This document was automatically generated with bibtex2html 1.97
      (see http://www.lri.fr/~filliatr/bibtex2html/),
      with the following command:
      /usr/bin/bibtex2html -a -t "Citations for the LMFDB" -header  -footer  -nofooter -f url -html-entities citations.bib  -->
@@ -54,7 +54,7 @@ Benjamin Antieau and Lennart Meier.
 </td>
 <td class="bibtexitem">
 Yuri Bachilov.
- On statistics of the riemann zeros differences.
+ On statistics of the Riemann zeros differences.
  <em>arXiv preprint arXiv:1402.0865</em>, 2014.
 [&nbsp;<a href="citations_bib.html#bachilov2014statistics">bib</a>&nbsp;]
 
@@ -68,7 +68,7 @@ Yuri Bachilov.
 </td>
 <td class="bibtexitem">
 Michael Baker.
- Elliptic curves over finite fields and their l-torsion galois
+ Elliptic curves over finite fields and their l-torsion Galois
   representations.
  M.s., 2015.
 [&nbsp;<a href="citations_bib.html#baker2015elliptic">bib</a>&nbsp;]
@@ -248,7 +248,7 @@ Jim Brown, Alfeen Hasmani, Lindsey Hiltner, Angela Kraft, Daniel Scofield, and
 </td>
 <td class="bibtexitem">
 Fran&ccedil;ois Brunault and Masataka Chida.
- Regulators for rankin-selberg products of modular forms.
+ Regulators for Rankin-Selberg products of modular forms.
  <em>Annales math&eacute;matiques du Qu&eacute;bec</em>, pages 1&ndash;29, 2016.
 [&nbsp;<a href="citations_bib.html#brunault2015regulators">bib</a>&nbsp;]
 
@@ -347,7 +347,7 @@ Hee-Joong Chung, Dohyeong Kim, Minhyong Kim, Jeehoon Park, and Hwajong Yoo.
 </td>
 <td class="bibtexitem">
 Henri Cohen.
- Computational number theory in relation with l-functions.
+ Computational number theory in relation with L-functions.
 [&nbsp;<a href="citations_bib.html#cohencomputational">bib</a>&nbsp;| 
 <a href="http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf">.pdf</a>&nbsp;]
 
@@ -375,7 +375,7 @@ Henri Cohen and Frank Thorne.
 </td>
 <td class="bibtexitem">
 LMFDB Collaboration et&nbsp;al.
- The l-functions and modular forms database (2016), 2016.
+ The L-functions and modular forms database (2016), 2016.
 [&nbsp;<a href="citations_bib.html#lmfdb2016functions">bib</a>&nbsp;| 
 <a href="http://lmfdb.org">http</a>&nbsp;]
 
@@ -404,7 +404,7 @@ Brian Conrey.
 </td>
 <td class="bibtexitem">
 Ian&nbsp;A Cooper, Patrick&nbsp;W Morris, and Nina&nbsp;C Snaith.
- Beyond the excised ensemble: modelling elliptic curve l-functions
+ Beyond the excised ensemble: modelling elliptic curve L-functions
   with random matrices.
  <em>Journal of Physics A: Mathematical and Theoretical</em>,
   49(7):075202, 2016.
@@ -506,7 +506,7 @@ Paul-Olivier Dehaye, Michael Kohlhase, Alexander Konovalov, Samuel
 </td>
 <td class="bibtexitem">
 Alyson Deines, Jenny&nbsp;G Fuselier, Ling Long, Holly Swisher, and Fang-Ting Tu.
- Generalized legendre curves and quaternionic multiplication.
+ Generalized Legendre curves and quaternionic multiplication.
  <em>Journal of Number Theory</em>, 161:175&ndash;203, 2016.
 [&nbsp;<a href="citations_bib.html#deines2016generalized">bib</a>&nbsp;]
 
@@ -590,7 +590,7 @@ David&nbsp;W Farmer and Sally Koutsoliotas.
 </td>
 <td class="bibtexitem">
 David&nbsp;W Farmer, Sally Koutsoliotas, and Stefan Lemurell.
- Maass forms on gl(3) and gl(4).
+ Maass forms on GL(3) and GL(4).
  <em>International mathematics research notices</em>,
   2014(22):6276&ndash;6301, 2014.
 [&nbsp;<a href="citations_bib.html#farmer2014maass">bib</a>&nbsp;]
@@ -605,7 +605,7 @@ David&nbsp;W Farmer, Sally Koutsoliotas, and Stefan Lemurell.
 </td>
 <td class="bibtexitem">
 David&nbsp;W Farmer, Sally Koutsoliotas, and Stefan Lemurell.
- Varieties via their l-functions.
+ Varieties via their L-functions.
  <em>arXiv preprint arXiv:1502.00850</em>, 2015.
 [&nbsp;<a href="citations_bib.html#farmer2015varieties">bib</a>&nbsp;]
 
@@ -619,8 +619,8 @@ David&nbsp;W Farmer, Sally Koutsoliotas, and Stefan Lemurell.
 </td>
 <td class="bibtexitem">
 Francesc Fit&eacute; and Xavier Guitart.
- Fields of definition of elliptic  <em>k</em> -curves and the realizability
-  of all genus 2 sato&ndash;tate groups over a number field.
+ Fields of definition of elliptic <em>k</em>-curves and the realizability of
+  all genus 2 Sato-Tate groups over a number field.
  <em>arXiv preprint arXiv:1511.02322</em>, 2015.
 [&nbsp;<a href="citations_bib.html#fite2015fields">bib</a>&nbsp;]
 
@@ -634,7 +634,7 @@ Francesc Fit&eacute; and Xavier Guitart.
 </td>
 <td class="bibtexitem">
 Francesc Fit&eacute;, Kiran&nbsp;S Kedlaya, and Andrew&nbsp;V Sutherland.
- Sato-tate groups of some weight 3 motives.
+ Sato-Tate groups of some weight 3 motives.
  <em>Contemporary Mathematics</em>, 663:57&ndash;102, 2016.
 [&nbsp;<a href="citations_bib.html#fite2012sato">bib</a>&nbsp;]
 
@@ -662,7 +662,7 @@ Alejandro&nbsp;Arg&aacute;ez Garc&iacute;a.
 </td>
 <td class="bibtexitem">
 Alexandru Ghitza, Nathan&nbsp;C Ryan, and David Sulon.
- Computations of vector-valued siegel modular forms.
+ Computations of vector-valued Siegel modular forms.
  <em>Journal of Number Theory</em>, 133(11):3921&ndash;3940, 2013.
 [&nbsp;<a href="citations_bib.html#ghitza2013computations">bib</a>&nbsp;]
 
@@ -676,7 +676,7 @@ Alexandru Ghitza, Nathan&nbsp;C Ryan, and David Sulon.
 </td>
 <td class="bibtexitem">
 Lo&iuml;c Greni&eacute; and Giuseppe Molteni.
- Zeros of dedekind zeta functions under grh.
+ Zeros of Dedekind zeta functions under GRH.
  <em>Mathematics of Computation</em>, 85:1503&ndash;1522, 2015.
 [&nbsp;<a href="citations_bib.html#grenie2015zeros">bib</a>&nbsp;]
 
@@ -719,8 +719,8 @@ Erhan G&uuml;rel.
 </td>
 <td class="bibtexitem">
 Katherine&nbsp;Elizabeth Harris.
- Random matrix theory and the attraction of zeros of l-functions from
-  the central point.
+ Random matrix theory and the attraction of zeros of L-functions
+  from the central point.
  Honors, 2015.
 [&nbsp;<a href="citations_bib.html#harris2015random">bib</a>&nbsp;]
 
@@ -734,7 +734,7 @@ Katherine&nbsp;Elizabeth Harris.
 </td>
 <td class="bibtexitem">
 David Harvey, Maike Massierer, and Andrew&nbsp;V Sutherland.
- Computing l-series of geometrically hyperelliptic curves of genus
+ Computing L-series of geometrically hyperelliptic curves of genus
   three.
  <em>arXiv preprint arXiv:1605.04708</em>, 2016.
 [&nbsp;<a href="citations_bib.html#harvey2016computing">bib</a>&nbsp;]
@@ -779,7 +779,7 @@ Thomas&nbsp;A Hulse, Chan&nbsp;Ieong Kuan, Eren&nbsp;Mehmet Kiral, and Li-Mei Li
 <td class="bibtexitem">
 Robert Jenkins and Ken DT-R McLaughlin.
  Dynamic behavior of the roots of the taylor polynomials of the
-  riemann xi function with growing degree.
+  Riemann xi function with growing degree.
  <em>arXiv preprint arXiv:1609.05965</em>, 2016.
 [&nbsp;<a href="citations_bib.html#jenkins2016dynamic">bib</a>&nbsp;]
 
@@ -793,8 +793,8 @@ Robert Jenkins and Ken DT-R McLaughlin.
 </td>
 <td class="bibtexitem">
 Jennifer Johnson-Leung and Brooks Roberts.
- Fourier coefficients for twists of siegel paramodular forms (expanded
-  version).
+ Fourier coefficients for twists of Siegel paramodular forms
+  (expanded version).
  <em>arXiv preprint arXiv:1505.05463</em>, 2015.
 [&nbsp;<a href="citations_bib.html#johnson2015fourier">bib</a>&nbsp;]
 
@@ -850,8 +850,8 @@ John&nbsp;W Jones and David&nbsp;P Roberts.
 </td>
 <td class="bibtexitem">
 Anatole Katok, Svetlana Katok, and Federico&nbsp;Rodriguez Hertz.
- The fried average entropy and slow entropy for actions of higher rank
-  abelian groups.
+ The Fried average entropy and slow entropy for actions of higher
+  rank abelian groups.
  <em>Geometric and Functional Analysis</em>, 24(4):1204&ndash;1228, 2014.
 [&nbsp;<a href="citations_bib.html#katok2014fried">bib</a>&nbsp;]
 
@@ -867,7 +867,7 @@ Anatole Katok, Svetlana Katok, and Federico&nbsp;Rodriguez Hertz.
 Albrecht Klemm, Maximilian Poretschkin, Thorsten Schimannek, and Martin
   Westerholt-Raum.
  Direct integration for mirror curves of genus two and an almost
-  meromorphic siegel modular form.
+  meromorphic Siegel modular form.
  <em>arXiv preprint arXiv:1502.00557</em>, 2015.
 [&nbsp;<a href="citations_bib.html#klemm2015direct">bib</a>&nbsp;]
 
@@ -896,7 +896,7 @@ Angelos Koutsianas.
 </td>
 <td class="bibtexitem">
 Alain Kraus.
- Sur le th&eacute;or&egrave;me de fermat sur q(&radic;(5).
+ Sur le th&eacute;or&egrave;me de fermat sur <em>Q</em>(&radic;(5).
  <em>Annales math&eacute;matiques du Qu&eacute;bec</em>, 39(1):49&ndash;59, 2015.)
 [&nbsp;<a href="citations_bib.html#kraus2015theoreme">bib</a>&nbsp;]
 
@@ -910,7 +910,7 @@ Alain Kraus.
 </td>
 <td class="bibtexitem">
 Abhinav Kumar and Ronen&nbsp;E Mukamel.
- Algebraic models and arithmetic geometry of teichm&uuml;ller curves in
+ Algebraic models and arithmetic geometry of Teichm&uuml;ller curves in
   genus two.
  <em>arXiv preprint arXiv:1406.7057</em>, 2014.
 [&nbsp;<a href="citations_bib.html#kumar2014algebraic">bib</a>&nbsp;]
@@ -925,7 +925,7 @@ Abhinav Kumar and Ronen&nbsp;E Mukamel.
 </td>
 <td class="bibtexitem">
 Wen-Ching&nbsp;Winnie Li, Tong Liu, and Ling Long.
- Potentially <em>GL</em><sub>2</sub>-type galois representations associated to
+ Potentially GL<sub>2</sub>-type Galois representations associated to
   noncongruence modular forms.
  <em>arXiv preprint arXiv:1609.06414</em>, 2016.
 [&nbsp;<a href="citations_bib.html#li2016potentially">bib</a>&nbsp;]
@@ -968,7 +968,7 @@ Benjamin Linowitz.
 </td>
 <td class="bibtexitem">
 Benjamin Linowitz, Matthew Satriano, and Roope Vehkalahti.
- A noncommutative analogue of the odlyzko bounds and bounds on
+ A noncommutative analogue of the Odlyzko bounds and bounds on
   performance for space-time lattice codes.
  <em>Information Theory, IEEE Transactions on</em>, 61(4):1971&ndash;1984,
   2015.
@@ -999,7 +999,7 @@ Benjamin Linowitz and John Voight.
 <td class="bibtexitem">
 Ling Long, Rafael Plaza, Peter Sin, and Qing Xiang.
  Characterization of intersecting families of maximum size in
-  <em>PSL</em>(2,<em>q</em>).
+  PSL(2,<em>q</em>).
  <em>arXiv preprint arXiv:1608.07304</em>, 2016.
 [&nbsp;<a href="citations_bib.html#long2016characterization">bib</a>&nbsp;]
 
@@ -1028,8 +1028,7 @@ Kimball Martin.
 </td>
 <td class="bibtexitem">
 Pietro Mercuri.
- Equations and rational points of the modular curves  <em>x</em>^+ _0 (<em>p</em>)
-  .
+ Equations and rational points of the modular curves X<sup>+</sup><sub>0</sub>(<em>p</em>).
  <em>arXiv preprint arXiv:1607.04558</em>, 2016.
 [&nbsp;<a href="citations_bib.html#mercuri2016equations">bib</a>&nbsp;]
 
@@ -1043,7 +1042,7 @@ Pietro Mercuri.
 </td>
 <td class="bibtexitem">
 Michael&nbsp;H Mertens.
- Eichler-selberg type identities for mixed mock modular forms.
+ Eichler-Selberg type identities for mixed mock modular forms.
  <em>arXiv preprint arXiv:1404.5491</em>, 2014.
 [&nbsp;<a href="citations_bib.html#mertens2014eichler">bib</a>&nbsp;]
 
@@ -1067,23 +1066,7 @@ Michael&nbsp;Helmut Mertens.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="michaelinteroperability">73</a>]
-</td>
-<td class="bibtexitem">
-Paul-Olivier Dehaye1 Mihnea&nbsp;Iancu Michael, Kohlhase2&nbsp;Alexander Konovalov,
-  Samuel Lelievre4 Dennis&nbsp;M&uuml;ller Markus, Pfeiffer3&nbsp;Florian Rabe, and
-  Nicolas M Thi&eacute;ry4&nbsp;Tom Wiesing.
- Interoperability in the opendreamkit project: The math-in-the-middle
-  approach.
-[&nbsp;<a href="citations_bib.html#michaelinteroperability">bib</a>&nbsp;]
-
-</td>
-</tr>
-
-
-<tr valign="top">
-<td align="right" class="bibtexnumber">
-[<a name="minemodular">74</a>]
+[<a name="minemodular">73</a>]
 </td>
 <td class="bibtexitem">
 Alex Mine.
@@ -1097,12 +1080,12 @@ Alex Mine.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="mosunov2015unconditional">75</a>]
+[<a name="mosunov2015unconditional">74</a>]
 </td>
 <td class="bibtexitem">
 A&nbsp;Mosunov and M&nbsp;Jacobson&nbsp;Jr.
  Unconditional class group tabulation of imaginary quadratic fields to
-  |&delta;|&lt;2<sup>40</sup>.
+  |&Delta;|&lt;2<sup>40</sup>.
  <em>Mathematics of Computation</em>, 85:1983&ndash;2009, 2016.
 [&nbsp;<a href="citations_bib.html#mosunov2015unconditional">bib</a>&nbsp;]
 
@@ -1112,11 +1095,11 @@ A&nbsp;Mosunov and M&nbsp;Jacobson&nbsp;Jr.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="nelson2016quantum">76</a>]
+[<a name="nelson2016quantum">75</a>]
 </td>
 <td class="bibtexitem">
 Paul&nbsp;D Nelson.
- Quantum variance on quaternion algebras, i.
+ Quantum variance on quaternion algebras, I.
  <em>arXiv preprint arXiv:1601.02526</em>, 2016.
 [&nbsp;<a href="citations_bib.html#nelson2016quantum">bib</a>&nbsp;]
 
@@ -1126,7 +1109,7 @@ Paul&nbsp;D Nelson.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="pastor2016regularity">77</a>]
+[<a name="pastor2016regularity">76</a>]
 </td>
 <td class="bibtexitem">
 Carlos Pastor.
@@ -1140,11 +1123,11 @@ Carlos Pastor.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="patrikis2015deformations">78</a>]
+[<a name="patrikis2015deformations">77</a>]
 </td>
 <td class="bibtexitem">
 Stefan Patrikis.
- Deformations of galois representations and exceptional monodromy.
+ Deformations of Galois representations and exceptional monodromy.
  <em>Inventiones mathematicae</em>, pages 1&ndash;68, 2015.
 [&nbsp;<a href="citations_bib.html#patrikis2015deformations">bib</a>&nbsp;]
 
@@ -1154,7 +1137,7 @@ Stefan Patrikis.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="platt2015computing">79</a>]
+[<a name="platt2015computing">78</a>]
 </td>
 <td class="bibtexitem">
 David Platt.
@@ -1168,7 +1151,7 @@ David Platt.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="plouffe2013values">80</a>]
+[<a name="plouffe2013values">79</a>]
 </td>
 <td class="bibtexitem">
 Simon Plouffe.
@@ -1182,11 +1165,11 @@ Simon Plouffe.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="rahm2013level">81</a>]
+[<a name="rahm2013level">80</a>]
 </td>
 <td class="bibtexitem">
 Alexander&nbsp;D Rahm and Mehmet&nbsp;Haluk Seng&uuml;n.
- On level one cuspidal bianchi modular forms.
+ On level one cuspidal Bianchi modular forms.
  <em>LMS Journal of Computation and Mathematics</em>, 16:187&ndash;199, 2013.
 [&nbsp;<a href="citations_bib.html#rahm2013level">bib</a>&nbsp;]
 
@@ -1196,7 +1179,7 @@ Alexander&nbsp;D Rahm and Mehmet&nbsp;Haluk Seng&uuml;n.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ramakrishnan2015number">82</a>]
+[<a name="ramakrishnan2015number">81</a>]
 </td>
 <td class="bibtexitem">
 B&nbsp;Ramakrishnan and Brundaban Sahu.
@@ -1212,7 +1195,7 @@ B&nbsp;Ramakrishnan and Brundaban Sahu.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ramakrishnan2013evaluation">83</a>]
+[<a name="ramakrishnan2013evaluation">82</a>]
 </td>
 <td class="bibtexitem">
 B&nbsp;Ramakrishnan and Brundaban Sahu.
@@ -1228,7 +1211,7 @@ B&nbsp;Ramakrishnan and Brundaban Sahu.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ramakrishnan2014number">84</a>]
+[<a name="ramakrishnan2014number">83</a>]
 </td>
 <td class="bibtexitem">
 B&nbsp;Ramakrishnan and Brundaban Sahu.
@@ -1244,7 +1227,7 @@ B&nbsp;Ramakrishnan and Brundaban Sahu.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ramakrishnan2016representations">85</a>]
+[<a name="ramakrishnan2016representations">84</a>]
 </td>
 <td class="bibtexitem">
 B&nbsp;Ramakrishnan, Brundaban Sahu, and Anup&nbsp;Kumar Singh.
@@ -1259,11 +1242,11 @@ B&nbsp;Ramakrishnan, Brundaban Sahu, and Anup&nbsp;Kumar Singh.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="roe2016algebraic">86</a>]
+[<a name="roe2016algebraic">85</a>]
 </td>
 <td class="bibtexitem">
 David Roe.
- Algebraic tori and a computational inverse galois problem, 2016.
+ Algebraic tori and a computational inverse Galois problem, 2016.
 [&nbsp;<a href="citations_bib.html#roe2016algebraic">bib</a>&nbsp;| 
 <a href="http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf">.pdf</a>&nbsp;]
 
@@ -1273,12 +1256,12 @@ David Roe.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="rouse2013explicit">87</a>]
+[<a name="rouse2013explicit">86</a>]
 </td>
 <td class="bibtexitem">
 Jeremy Rouse and Jesse Thorner.
- The explicit sato-tate conjecture and densities pertaining to
-  lehmer-type questions.
+ The explicit Sato-Tate conjecture and densities pertaining to
+  Lehmer-type questions.
  <em>Transactions of the AMS</em>, 2016.
  to appear.
 [&nbsp;<a href="citations_bib.html#rouse2013explicit">bib</a>&nbsp;]
@@ -1289,12 +1272,12 @@ Jeremy Rouse and Jesse Thorner.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="rubinstein2013elliptic">88</a>]
+[<a name="rubinstein2013elliptic">87</a>]
 </td>
 <td class="bibtexitem">
 Michael&nbsp;O Rubinstein.
- Elliptic curves of high rank and the riemann zeta function on the one
-  line.
+ Elliptic curves of high rank and the Riemann zeta function on the
+  one line.
  <em>Experimental Mathematics</em>, 22(4):465&ndash;480, 2013.
 [&nbsp;<a href="citations_bib.html#rubinstein2013elliptic">bib</a>&nbsp;]
 
@@ -1304,7 +1287,7 @@ Michael&nbsp;O Rubinstein.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="rubinstein2015moments">89</a>]
+[<a name="rubinstein2015moments">88</a>]
 </td>
 <td class="bibtexitem">
 Michael&nbsp;O Rubinstein and Kaiyu Wu.
@@ -1320,12 +1303,12 @@ Michael&nbsp;O Rubinstein and Kaiyu Wu.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ryan2016computing">90</a>]
+[<a name="ryan2016computing">89</a>]
 </td>
 <td class="bibtexitem">
 Nathan&nbsp;C Ryan, Nicol&aacute;s Sirolli, Nils-Peter Skoruppa, and Gonzalo
   Tornar&iacute;a.
- Computing jacobi forms.
+ Computing Jacobi forms.
  <em>arXiv preprint arXiv:1602.07021</em>, 2016.
 [&nbsp;<a href="citations_bib.html#ryan2016computing">bib</a>&nbsp;]
 
@@ -1335,11 +1318,11 @@ Nathan&nbsp;C Ryan, Nicol&aacute;s Sirolli, Nils-Peter Skoruppa, and Gonzalo
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ryan2014nonvanishing">91</a>]
+[<a name="ryan2014nonvanishing">90</a>]
 </td>
 <td class="bibtexitem">
 Nathan&nbsp;C Ryan, Gonzalo Tornaria, and John Voight.
- Nonvanishing of twists of-functions attached to hilbert modular
+ Nonvanishing of twists of-functions attached to Hilbert modular
   forms.
  <em>LMS Journal of Computation and Mathematics</em>, 17(A):330&ndash;348,
   2014.
@@ -1351,7 +1334,7 @@ Nathan&nbsp;C Ryan, Gonzalo Tornaria, and John Voight.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="sairaiji2016class">92</a>]
+[<a name="sairaiji2016class">91</a>]
 </td>
 <td class="bibtexitem">
 Fumio Sairaiji and Takuya Yamauchi.
@@ -1366,7 +1349,7 @@ Fumio Sairaiji and Takuya Yamauchi.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="saouter2015still">93</a>]
+[<a name="saouter2015still">92</a>]
 </td>
 <td class="bibtexitem">
 Yannick Saouter, Timothy Trudgian, and Patrick Demichel.
@@ -1380,7 +1363,7 @@ Yannick Saouter, Timothy Trudgian, and Patrick Demichel.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="savala2016computing">94</a>]
+[<a name="savala2016computing">93</a>]
 </td>
 <td class="bibtexitem">
 Paul Savala.
@@ -1394,7 +1377,7 @@ Paul Savala.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="schaeffer2015hecke">95</a>]
+[<a name="schaeffer2015hecke">94</a>]
 </td>
 <td class="bibtexitem">
 George&nbsp;J Schaeffer.
@@ -1408,7 +1391,7 @@ George&nbsp;J Schaeffer.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="sha2014pseudolinearly">96</a>]
+[<a name="sha2014pseudolinearly">95</a>]
 </td>
 <td class="bibtexitem">
 Min Sha and Igor&nbsp;E Shparlinski.
@@ -1422,11 +1405,11 @@ Min Sha and Igor&nbsp;E Shparlinski.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="sohexplicit">97</a>]
+[<a name="sohexplicit">96</a>]
 </td>
 <td class="bibtexitem">
 Charlene Soh.
- Explicit methods for the birch and swinnerton-dyer conjecture.
+ Explicit methods for the Birch and Swinnerton-Dyer conjecture.
  Msc.
 [&nbsp;<a href="citations_bib.html#sohexplicit">bib</a>&nbsp;]
 
@@ -1436,11 +1419,11 @@ Charlene Soh.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="sutherland2012computing">98</a>]
+[<a name="sutherland2012computing">97</a>]
 </td>
 <td class="bibtexitem">
 Andrew&nbsp;V Sutherland.
- Computing the image of galois.
+ Computing the image of Galois.
  <em>CNTA XII</em>, page&nbsp;22, 2012.
 [&nbsp;<a href="citations_bib.html#sutherland2012computing">bib</a>&nbsp;]
 
@@ -1450,11 +1433,11 @@ Andrew&nbsp;V Sutherland.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="sutherland2015computing">99</a>]
+[<a name="sutherland2015computing">98</a>]
 </td>
 <td class="bibtexitem">
 Andrew&nbsp;V Sutherland.
- Computing images of galois representations attached to elliptic
+ Computing images of Galois representations attached to elliptic
   curves.
  <em>Forum of Mathematics, Sigma</em>, 4:79 pages, 2016.
 [&nbsp;<a href="citations_bib.html#sutherland2015computing">bib</a>&nbsp;]
@@ -1465,11 +1448,11 @@ Andrew&nbsp;V Sutherland.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="swinarski2016equations">100</a>]
+[<a name="swinarski2016equations">99</a>]
 </td>
 <td class="bibtexitem">
 David Swinarski.
- Equations of riemann surfaces with automorphisms.
+ Equations of Riemann surfaces with automorphisms.
  <em>arXiv preprint arXiv:1607.04778</em>, 2016.
 [&nbsp;<a href="citations_bib.html#swinarski2016equations">bib</a>&nbsp;]
 
@@ -1479,7 +1462,7 @@ David Swinarski.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="MR3100414">101</a>]
+[<a name="MR3100414">100</a>]
 </td>
 <td class="bibtexitem">
 Audrey Terras.
@@ -1495,7 +1478,7 @@ Audrey Terras.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="ugolini2015functional">102</a>]
+[<a name="ugolini2015functional">101</a>]
 </td>
 <td class="bibtexitem">
 Simone Ugolini.
@@ -1510,7 +1493,7 @@ Simone Ugolini.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="viada2016explicit">103</a>]
+[<a name="viada2016explicit">102</a>]
 </td>
 <td class="bibtexitem">
 Evelina Viada.
@@ -1525,11 +1508,11 @@ Evelina Viada.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="waltoncongruent">104</a>]
+[<a name="waltoncongruent">103</a>]
 </td>
 <td class="bibtexitem">
 Florence Walton.
- The congruent number problem and the birch and swinnerton-dyer
+ The congruent number problem and the Birch and Swinnerton-Dyer
   conjecture.
  Mmathphil.
 [&nbsp;<a href="citations_bib.html#waltoncongruent">bib</a>&nbsp;]
@@ -1540,7 +1523,7 @@ Florence Walton.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="wan2014slopes">105</a>]
+[<a name="wan2014slopes">104</a>]
 </td>
 <td class="bibtexitem">
 Daqing Wan, Liang Xiao, and Jun Zhang.
@@ -1554,7 +1537,7 @@ Daqing Wan, Liang Xiao, and Jun Zhang.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="zhu2015more">106</a>]
+[<a name="zhu2015more">105</a>]
 </td>
 <td class="bibtexitem">
 Yan Zhu, Eiichi Bannai, Etsuko Bannai, Kyoung-Tark Kim, and Wei-Hsuan Yu.
@@ -1568,7 +1551,7 @@ Yan Zhu, Eiichi Bannai, Etsuko Bannai, Kyoung-Tark Kim, and Wei-Hsuan Yu.
 
 <tr valign="top">
 <td align="right" class="bibtexnumber">
-[<a name="横山俊一2013統合システム">107</a>]
+[<a name="横山俊一2013統合システム">106</a>]
 </td>
 <td class="bibtexitem">
 横山俊一.

--- a/citations_bib.html
+++ b/citations_bib.html
@@ -29,7 +29,7 @@
 
 <a name="li2016potentially"></a><pre>
 @article{<a href="citations.html#li2016potentially">li2016potentially</a>,
-  title = {Potentially $\text{GL}_2$-type Galois representations associated to noncongruence modular forms},
+  title = {Potentially {GL}$_2$-type {Galois} representations associated to noncongruence modular forms},
   author = {Li, Wen-Ching Winnie and Liu, Tong and Long, Ling},
   journal = {arXiv preprint arXiv:1609.06414},
   year = {2016}
@@ -47,7 +47,7 @@
 
 <a name="jenkins2016dynamic"></a><pre>
 @article{<a href="citations.html#jenkins2016dynamic">jenkins2016dynamic</a>,
-  title = {Dynamic behavior of the roots of the Taylor polynomials of the Riemann xi function with growing degree},
+  title = {Dynamic behavior of the roots of the Taylor polynomials of the {Riemann} xi function with growing degree},
   author = {Jenkins, Robert and McLaughlin, Ken DT-R},
   journal = {arXiv preprint arXiv:1609.05965},
   year = {2016}
@@ -65,7 +65,7 @@
 
 <a name="long2016characterization"></a><pre>
 @article{<a href="citations.html#long2016characterization">long2016characterization</a>,
-  title = {Characterization of intersecting families of maximum size in $\text{PSL}(2,q)$},
+  title = {Characterization of intersecting families of maximum size in {PSL}$(2,q)$},
   author = {Long, Ling and Plaza, Rafael and Sin, Peter and Xiang, Qing},
   journal = {arXiv preprint arXiv:1608.07304},
   year = {2016}
@@ -135,7 +135,7 @@
 
 <a name="harvey2016computing"></a><pre>
 @article{<a href="citations.html#harvey2016computing">harvey2016computing</a>,
-  title = {Computing L-series of geometrically hyperelliptic curves of genus three},
+  title = {Computing {L}-series of geometrically hyperelliptic curves of genus three},
   author = {Harvey, David and Massierer, Maike and Sutherland, Andrew V},
   journal = {arXiv preprint arXiv:1605.04708},
   year = {2016}
@@ -164,16 +164,9 @@
 }
 </pre>
 
-<a name="michaelinteroperability"></a><pre>
-@article{<a href="citations.html#michaelinteroperability">michaelinteroperability</a>,
-  title = {Interoperability in the OpenDreamKit Project: The Math-in-the-Middle Approach},
-  author = {Michael, Paul-Olivier Dehaye1 Mihnea Iancu and Konovalov, Kohlhase2 Alexander and Markus, Samuel Lelievre4 Dennis M{\"u}ller and Rabe, Pfeiffer3 Florian and Wiesing, Nicolas M Thi{\'e}ry4 Tom}
-}
-</pre>
-
 <a name="mercuri2016equations"></a><pre>
 @article{<a href="citations.html#mercuri2016equations">mercuri2016equations</a>,
-  title = {Equations and Rational Points of the Modular Curves $ X\^{}+ \_0 (p) $},
+  title = {Equations and Rational Points of the Modular Curves {X}$^+_0(p)$},
   author = {Mercuri, Pietro},
   journal = {arXiv preprint arXiv:1607.04558},
   year = {2016}
@@ -182,7 +175,7 @@
 
 <a name="swinarski2016equations"></a><pre>
 @article{<a href="citations.html#swinarski2016equations">swinarski2016equations</a>,
-  title = {Equations of Riemann surfaces with automorphisms},
+  title = {Equations of {Riemann} surfaces with automorphisms},
   author = {Swinarski, David},
   journal = {arXiv preprint arXiv:1607.04778},
   year = {2016}
@@ -217,7 +210,7 @@
 
 <a name="sutherland2012computing"></a><pre>
 @article{<a href="citations.html#sutherland2012computing">sutherland2012computing</a>,
-  title = {Computing the image of Galois},
+  title = {Computing the image of {Galois}},
   author = {Sutherland, Andrew V},
   journal = {CNTA XII},
   pages = {22},
@@ -227,7 +220,7 @@
 
 <a name="roe2016algebraic"></a><pre>
 @misc{<a href="citations.html#roe2016algebraic">roe2016algebraic</a>,
-  title = {Algebraic tori and a computational inverse Galois problem},
+  title = {Algebraic tori and a computational inverse {Galois} problem},
   author = {Roe, David},
   url = {<a href="http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf">http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf</a>},
   year = {2016}
@@ -247,7 +240,7 @@
 
 <a name="lmfdb2016functions"></a><pre>
 @misc{<a href="citations.html#lmfdb2016functions">lmfdb2016functions</a>,
-  title = {The L-functions and Modular Forms Database (2016)},
+  title = {The {L}-functions and Modular Forms Database (2016)},
   author = {LMFDB Collaboration and others},
   url = {<a href="http://lmfdb.org">http://lmfdb.org</a>},
   year = {2016}
@@ -298,7 +291,7 @@
 
 <a name="patrikis2015deformations"></a><pre>
 @article{<a href="citations.html#patrikis2015deformations">patrikis2015deformations</a>,
-  title = {Deformations of Galois representations and exceptional monodromy},
+  title = {Deformations of {Galois} representations and exceptional monodromy},
   author = {Patrikis, Stefan},
   journal = {Inventiones mathematicae},
   pages = {1--68},
@@ -309,7 +302,7 @@
 
 <a name="johnson2015fourier"></a><pre>
 @article{<a href="citations.html#johnson2015fourier">johnson2015fourier</a>,
-  title = {Fourier coefficients for twists of Siegel paramodular forms (expanded version)},
+  title = {Fourier coefficients for twists of {Siegel} paramodular forms (expanded version)},
   author = {Johnson-Leung, Jennifer and Roberts, Brooks},
   journal = {arXiv preprint arXiv:1505.05463},
   year = {2015}
@@ -327,7 +320,7 @@
 
 <a name="klemm2015direct"></a><pre>
 @article{<a href="citations.html#klemm2015direct">klemm2015direct</a>,
-  title = {Direct Integration for Mirror Curves of Genus Two and an Almost Meromorphic Siegel Modular Form},
+  title = {Direct Integration for Mirror Curves of Genus Two and an Almost Meromorphic {Siegel} Modular Form},
   author = {Klemm, Albrecht and Poretschkin, Maximilian and Schimannek, Thorsten and Westerholt-Raum, Martin},
   journal = {arXiv preprint arXiv:1502.00557},
   year = {2015}
@@ -345,7 +338,7 @@
 
 <a name="nelson2016quantum"></a><pre>
 @article{<a href="citations.html#nelson2016quantum">nelson2016quantum</a>,
-  title = {Quantum variance on quaternion algebras, I},
+  title = {Quantum variance on quaternion algebras, {I}},
   author = {Nelson, Paul D},
   journal = {arXiv preprint arXiv:1601.02526},
   year = {2016}
@@ -354,7 +347,7 @@
 
 <a name="grenie2015zeros"></a><pre>
 @article{<a href="citations.html#grenie2015zeros">grenie2015zeros</a>,
-  title = {Zeros of Dedekind zeta functions under GRH},
+  title = {Zeros of {Dedekind} zeta functions under {GRH}},
   author = {Greni{\'e}, Lo{\"\i}c and Molteni, Giuseppe},
   journal = {Mathematics of Computation},
   volume = {85},
@@ -365,7 +358,7 @@
 
 <a name="ryan2016computing"></a><pre>
 @article{<a href="citations.html#ryan2016computing">ryan2016computing</a>,
-  title = {Computing Jacobi Forms},
+  title = {Computing {Jacobi} Forms},
   author = {Ryan, Nathan C and Sirolli, Nicol{\'a}s and Skoruppa, Nils-Peter and Tornar{\'\i}a, Gonzalo},
   journal = {arXiv preprint arXiv:1602.07021},
   year = {2016}
@@ -374,7 +367,7 @@
 
 <a name="fite2015fields"></a><pre>
 @article{<a href="citations.html#fite2015fields">fite2015fields</a>,
-  title = {Fields of definition of elliptic $ k $-curves and the realizability of all genus 2 Sato--Tate groups over a number field},
+  title = {Fields of definition of elliptic $k$-curves and the realizability of all genus 2 {Sato}-{Tate} groups over a number field},
   author = {Fit{\'e}, Francesc and Guitart, Xavier},
   journal = {arXiv preprint arXiv:1511.02322},
   year = {2015}
@@ -401,7 +394,7 @@
 
 <a name="cooper2016beyond"></a><pre>
 @article{<a href="citations.html#cooper2016beyond">cooper2016beyond</a>,
-  title = {Beyond the excised ensemble: modelling elliptic curve L-functions with random matrices},
+  title = {Beyond the excised ensemble: modelling elliptic curve {L}-functions with random matrices},
   author = {Cooper, Ian A and Morris, Patrick W and Snaith, Nina C},
   journal = {Journal of Physics A: Mathematical and Theoretical},
   volume = {49},
@@ -477,7 +470,7 @@
 
 <a name="mosunov2015unconditional"></a><pre>
 @article{<a href="citations.html#mosunov2015unconditional">mosunov2015unconditional</a>,
-  title = {Unconditional class group tabulation of imaginary quadratic fields to $|\Delta|<2^{40}$},
+  title = {Unconditional class group tabulation of imaginary quadratic fields to $|{\Delta}|<2^{40}$},
   author = {Mosunov, A and Jacobson Jr,  M},
   journal = {Mathematics of Computation},
   volume = {85},
@@ -500,7 +493,7 @@
 
 <a name="rouse2013explicit"></a><pre>
 @article{<a href="citations.html#rouse2013explicit">rouse2013explicit</a>,
-  title = {The explicit Sato-Tate conjecture and densities pertaining to Lehmer-type questions},
+  title = {The explicit {Sato}-{Tate} conjecture and densities pertaining to {Lehmer}-type questions},
   author = {Rouse, Jeremy and Thorner, Jesse},
   journal = {Transactions of the AMS},
   note = {to appear},
@@ -520,7 +513,7 @@
 
 <a name="kraus2015theoreme"></a><pre>
 @article{<a href="citations.html#kraus2015theoreme">kraus2015theoreme</a>,
-  title = {Sur le th{\'e}or{\`e}me de Fermat sur $\mathbb Q(\sqrt5)$},
+  title = {Sur le th{\'e}or{\`e}me de Fermat sur $\mathbb{Q}(\sqrt5)$},
   author = {Kraus, Alain},
   journal = {Annales math{\'e}matiques du Qu{\'e}bec},
   volume = {39},
@@ -582,7 +575,7 @@
 
 <a name="sohexplicit"></a><pre>
 @mastersthesis{<a href="citations.html#sohexplicit">sohexplicit</a>,
-  title = {Explicit Methods for the Birch and Swinnerton-Dyer Conjecture},
+  title = {Explicit Methods for the {Birch} and {Swinnerton}-{Dyer} Conjecture},
   type = {MSc},
   institution = {University of Oxford},
   author = {Soh, Charlene}
@@ -628,7 +621,7 @@
 
 <a name="brunault2015regulators"></a><pre>
 @article{<a href="citations.html#brunault2015regulators">brunault2015regulators</a>,
-  title = {Regulators for Rankin-Selberg products of modular forms},
+  title = {Regulators for {Rankin}-{Selberg} products of modular forms},
   author = {Brunault, Fran{\c{c}}ois and Chida, Masataka},
   journal = {Annales math\'ematiques du Qu\'ebec},
   pages = {1--29},
@@ -638,7 +631,7 @@
 
 <a name="linowitz2015noncommutative"></a><pre>
 @article{<a href="citations.html#linowitz2015noncommutative">linowitz2015noncommutative</a>,
-  title = {A Noncommutative Analogue of the Odlyzko Bounds and Bounds on Performance for Space-Time Lattice Codes},
+  title = {A Noncommutative Analogue of the {Odlyzko} Bounds and Bounds on Performance for Space-Time Lattice Codes},
   author = {Linowitz, Benjamin and Satriano, Matthew and Vehkalahti, Roope},
   journal = {Information Theory, IEEE Transactions on},
   volume = {61},
@@ -651,7 +644,7 @@
 
 <a name="kumar2014algebraic"></a><pre>
 @article{<a href="citations.html#kumar2014algebraic">kumar2014algebraic</a>,
-  title = {Algebraic models and arithmetic geometry of Teichm\"uller curves in genus two},
+  title = {Algebraic models and arithmetic geometry of {Teichm\"uller} curves in genus two},
   author = {Kumar, Abhinav and Mukamel, Ronen E},
   journal = {arXiv preprint arXiv:1406.7057},
   year = {2014}
@@ -660,7 +653,7 @@
 
 <a name="cohencomputational"></a><pre>
 @misc{<a href="citations.html#cohencomputational">cohencomputational</a>,
-  title = {Computational number theory in relation with L-functions},
+  title = {Computational number theory in relation with {L}-functions},
   author = {Cohen, Henri},
   url = {<a href="http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf">http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf</a>}
 }
@@ -668,7 +661,7 @@
 
 <a name="sutherland2015computing"></a><pre>
 @article{<a href="citations.html#sutherland2015computing">sutherland2015computing</a>,
-  title = {Computing images of Galois representations attached to elliptic curves},
+  title = {Computing images of {Galois} representations attached to elliptic curves},
   author = {Sutherland, Andrew V},
   journal = {Forum of Mathematics, Sigma},
   volume = {4},
@@ -700,7 +693,7 @@
 
 <a name="ryan2014nonvanishing"></a><pre>
 @article{<a href="citations.html#ryan2014nonvanishing">ryan2014nonvanishing</a>,
-  title = {Nonvanishing of twists of-functions attached to Hilbert modular forms},
+  title = {Nonvanishing of twists of-functions attached to {Hilbert} modular forms},
   author = {Ryan, Nathan C and Tornaria, Gonzalo and Voight, John},
   journal = {LMS Journal of Computation and Mathematics},
   volume = {17},
@@ -713,7 +706,7 @@
 
 <a name="rahm2013level"></a><pre>
 @article{<a href="citations.html#rahm2013level">rahm2013level</a>,
-  title = {On level one cuspidal Bianchi modular forms},
+  title = {On level one cuspidal {Bianchi} modular forms},
   author = {Rahm, Alexander D and {\c{S}}eng{\"u}n, Mehmet Haluk},
   journal = {LMS Journal of Computation and Mathematics},
   volume = {16},
@@ -738,7 +731,7 @@
 
 <a name="waltoncongruent"></a><pre>
 @mastersthesis{<a href="citations.html#waltoncongruent">waltoncongruent</a>,
-  title = {The Congruent Number Problem and the Birch and Swinnerton-Dyer Conjecture},
+  title = {The Congruent Number Problem and the {Birch} and {Swinnerton}-{Dyer} Conjecture},
   type = {MMathPhil},
   institution = {University of Oxford},
   author = {Walton, Florence}
@@ -747,7 +740,7 @@
 
 <a name="ghitza2013computations"></a><pre>
 @article{<a href="citations.html#ghitza2013computations">ghitza2013computations</a>,
-  title = {Computations of vector-valued Siegel modular forms},
+  title = {Computations of vector-valued {Siegel} modular forms},
   author = {Ghitza, Alexandru and Ryan, Nathan C and Sulon, David},
   journal = {Journal of Number Theory},
   volume = {133},
@@ -760,7 +753,7 @@
 
 <a name="baker2015elliptic"></a><pre>
 @mastersthesis{<a href="citations.html#baker2015elliptic">baker2015elliptic</a>,
-  title = {Elliptic Curves over Finite Fields and their l-Torsion Galois Representations},
+  title = {Elliptic Curves over Finite Fields and their l-Torsion {Galois} Representations},
   type = {M.S.},
   author = {Baker, Michael},
   year = {2015},
@@ -783,7 +776,7 @@
 
 <a name="farmer2015varieties"></a><pre>
 @article{<a href="citations.html#farmer2015varieties">farmer2015varieties</a>,
-  title = {Varieties via their L-functions},
+  title = {Varieties via their {L}-functions},
   author = {Farmer, David W and Koutsoliotas, Sally and Lemurell, Stefan},
   journal = {arXiv preprint arXiv:1502.00850},
   year = {2015}
@@ -792,7 +785,7 @@
 
 <a name="harris2015random"></a><pre>
 @mastersthesis{<a href="citations.html#harris2015random">harris2015random</a>,
-  title = {Random Matrix Theory and the Attraction of Zeros of L-functions from the Central Point},
+  title = {Random Matrix Theory and the Attraction of Zeros of {L}-functions from the Central Point},
   author = {Harris, Katherine Elizabeth},
   type = {Honors},
   institution = {Bucknell University},
@@ -811,7 +804,7 @@
 
 <a name="mertens2014eichler"></a><pre>
 @article{<a href="citations.html#mertens2014eichler">mertens2014eichler</a>,
-  title = {Eichler-Selberg type identities for mixed mock modular forms},
+  title = {{Eichler}-{Selberg} type identities for mixed mock modular forms},
   author = {Mertens, Michael H},
   journal = {arXiv preprint arXiv:1404.5491},
   year = {2014}
@@ -829,7 +822,7 @@
 
 <a name="deines2016generalized"></a><pre>
 @article{<a href="citations.html#deines2016generalized">deines2016generalized</a>,
-  title = {Generalized Legendre curves and quaternionic multiplication},
+  title = {Generalized {Legendre} curves and quaternionic multiplication},
   author = {Deines, Alyson and Fuselier, Jenny G and Long, Ling and Swisher, Holly and Tu, Fang-Ting},
   journal = {Journal of Number Theory},
   volume = {161},
@@ -850,7 +843,7 @@
 
 <a name="rubinstein2013elliptic"></a><pre>
 @article{<a href="citations.html#rubinstein2013elliptic">rubinstein2013elliptic</a>,
-  title = {Elliptic curves of high rank and the Riemann zeta function on the one line},
+  title = {Elliptic curves of high rank and the {Riemann} zeta function on the one line},
   author = {Rubinstein, Michael O},
   journal = {Experimental Mathematics},
   volume = {22},
@@ -925,7 +918,7 @@
 
 <a name="katok2014fried"></a><pre>
 @article{<a href="citations.html#katok2014fried">katok2014fried</a>,
-  title = {The Fried average entropy and slow entropy for actions of higher rank abelian groups},
+  title = {The {Fried} average entropy and slow entropy for actions of higher rank abelian groups},
   author = {Katok, Anatole and Katok, Svetlana and Hertz, Federico Rodriguez},
   journal = {Geometric and Functional Analysis},
   volume = {24},
@@ -985,7 +978,7 @@
 
 <a name="farmer2014maass"></a><pre>
 @article{<a href="citations.html#farmer2014maass">farmer2014maass</a>,
-  title = {Maass Forms on GL(3) and GL(4)},
+  title = {Maass Forms on {GL}(3) and {GL}(4)},
   author = {Farmer, David W and Koutsoliotas, Sally and Lemurell, Stefan},
   journal = {International mathematics research notices},
   volume = {2014},
@@ -998,7 +991,7 @@
 
 <a name="bachilov2014statistics"></a><pre>
 @article{<a href="citations.html#bachilov2014statistics">bachilov2014statistics</a>,
-  title = {On Statistics of the Riemann Zeros Differences},
+  title = {On Statistics of the {Riemann} Zeros Differences},
   author = {Bachilov, Yuri},
   journal = {arXiv preprint arXiv:1402.0865},
   year = {2014}
@@ -1018,7 +1011,7 @@
 
 <a name="fite2012sato"></a><pre>
 @article{<a href="citations.html#fite2012sato">fite2012sato</a>,
-  title = {Sato-Tate groups of some weight 3 motives},
+  title = {{Sato}-{Tate} groups of some weight 3 motives},
   author = {Fit{\'e}, Francesc and Kedlaya, Kiran S and Sutherland, Andrew V},
   journal = {Contemporary Mathematics},
   volume = {663},


### PR DESCRIPTION
In the title field bibtex insists on removing capitals, and these need fixing manually.  Even $\Delta$ was turned into $\delta$ until I changed it to ${\Delta}$!
