### PR TITLE
Prevent `{{` or `}}` from appearing in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@
 lmfdb: citations.bib
 	bibtex2html -a -nodoc -header "" -footer "" -nofooter -f url -html-entities -o citations_content citations.bib
 	sed -i 's!citations_content\.html!/citation/citations!g' citations_content_bib.html
+	sed -i -e 's/{{/{ {/g' citations_content_bib.html
+	sed -i -e 's/}}/} }/g' citations_content_bib.html
 	sed -i 's!citations_content_bib\.html!/citation/citations_bib!g' citations_content.html
 
 # -d for sort by Date instead of alphabetical


### PR DESCRIPTION
The output generated from `make lmfdb` is placed into the lmfdb, which
has jinja expansion. The pattern `{{` and `}}` leads to errors, as these
indicate code in jinja. This commit has the `make lmfdb` command replace
each `{{` with `{ {` and `}}` with `} }`.